### PR TITLE
Fix modal item counts

### DIFF
--- a/resources/views/woocommerce/new.php
+++ b/resources/views/woocommerce/new.php
@@ -1516,6 +1516,10 @@ if ($product_id != 3947) echo 'disabled'; ?>>
         const closeBtn = document.getElementById("mobile-modal-close");
 
         function openMobileModal() {
+            // ensure product counts are up-to-date when the modal opens
+            if (typeof refreshMiniQuantityInputs === 'function') {
+                refreshMiniQuantityInputs();
+            }
             modal.classList.remove("hidden");
             modalContent.classList.remove("slide-down");
             modalContent.classList.add("slide-up");


### PR DESCRIPTION
## Summary
- sync quantities when mobile builder modal opens

## Testing
- `php -l resources/views/woocommerce/new.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eba73f6d0832ea4b4d334f0e049b2