### PR TITLE
Fix order-again donut box metadata

### DIFF
--- a/public/content/plugins/box-builder-woo/includes/order-again-functions.php
+++ b/public/content/plugins/box-builder-woo/includes/order-again-functions.php
@@ -34,6 +34,10 @@ function custom_order_again_cart_item_data($cart_item_data, $item, $order) {
 
 add_action('woocommerce_after_order_again_cart_item_added', 'add_child_items_to_cart_for_order_again', 10, 3);
 function add_child_items_to_cart_for_order_again($cart_item_key, $item, $order) {
+    if ($item->get_meta('_part_of_box') || $item->get_meta('_parent_item_key')) {
+        WC()->cart->remove_cart_item($cart_item_key);
+        return;
+    }
     // Get selected products from the order item meta
     $selected_products = $item->get_meta('_selected_products') ? explode(', ', $item->get_meta('_selected_products')) : [];
 
@@ -46,7 +50,7 @@ function add_child_items_to_cart_for_order_again($cart_item_key, $item, $order) 
             if (is_numeric($selected_product_id)) {
                 // Add each selected product to the cart as a child item
                 WC()->cart->add_to_cart(intval($selected_product_id), 1, 0, array(), array(
-                    'parent_item_key' => $cart_item_key,  // Link to the main product
+                    'parent_item_key' => $unique_key,  // Link to the main product
                     'part_of_box' => true,
                     'unique_key' => $unique_key,
                 ));
@@ -54,11 +58,6 @@ function add_child_items_to_cart_for_order_again($cart_item_key, $item, $order) 
         }
     }
 }
-
-
-add_action('woocommerce_after_order_again_cart_item_added', function($cart_item_key, $item, $order) {
-    wc_add_notice('Order again process triggered', 'notice');
-}, 10, 3);
 
 /*
 add_action('woocommerce_before_cart', 'dump_cart_contents');

--- a/public/content/plugins/box-builder-woo/includes/order-functions.php
+++ b/public/content/plugins/box-builder-woo/includes/order-functions.php
@@ -9,6 +9,12 @@ function add_metadata_to_order_items($item, $cart_item_key, $values, $order)
     if (isset($values['unique_key'])) {
         $item->add_meta_data('_unique_key', $values['unique_key'], true);
     }
+    if (isset($values['part_of_box'])) {
+        $item->add_meta_data('_part_of_box', $values['part_of_box'], true);
+    }
+    if (isset($values['parent_item_key'])) {
+        $item->add_meta_data('_parent_item_key', $values['parent_item_key'], true);
+    }
 
     // Add display metadata
     if (isset($values['custom_product_option'])) {


### PR DESCRIPTION
## Summary
- store `_part_of_box` and `_parent_item_key` metadata on order items
- avoid duplicating child items when using "Order Again"
- link recreated donut items to main box correctly
- drop debug notice hook

## Testing
- `php -l public/content/plugins/box-builder-woo/includes/order-functions.php` *(fails: command not found)*
- `php -l public/content/plugins/box-builder-woo/includes/order-again-functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865339b4a58832e9b8ce0d3eca0b486